### PR TITLE
Small example fixes

### DIFF
--- a/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
+++ b/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputType>exe</OutputType>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.xaml;Assets\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />

--- a/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
+++ b/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
@@ -7,7 +7,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="**\*.xaml;Assets\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
+    <EmbeddedResource Include="**\*.xaml;Assets\*;Images\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />

--- a/Source/Examples/Avalonia/AvaloniaExamples/Example.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Example.cs
@@ -4,6 +4,10 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Linq;
+using Avalonia;
+using Avalonia.Platform;
+
 namespace AvaloniaExamples
 {
     using Avalonia.Media.Imaging;
@@ -19,7 +23,10 @@ namespace AvaloniaExamples
             this.Description = description;
             try
             {
-                this.Thumbnail = new Bitmap("resm:Images/" + this.ThumbnailFileName);
+                var uri = new Uri("resm:AvaloniaExamples.Images." + this.ThumbnailFileName);
+                var assets = AvaloniaLocator.Current.GetService<IAssetLoader>();
+                var stream = assets.Open(uri);
+                this.Thumbnail = new Bitmap(stream);
             }
             catch (Exception e)
             {
@@ -37,7 +44,7 @@ namespace AvaloniaExamples
         {
             get
             {
-                return this.MainWindowType.Namespace + ".png";
+                return this.MainWindowType.Namespace.Split('.').Last() + ".png";
             }
         }
 

--- a/Source/Examples/Avalonia/AvaloniaExamples/Example.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Example.cs
@@ -19,7 +19,7 @@ namespace AvaloniaExamples
         public Example(Type mainWindowType, string title = null, string description = null)
         {
             this.MainWindowType = mainWindowType;
-            this.Title = title ?? mainWindowType.Namespace;
+            this.Title = title ?? mainWindowType.Namespace.Split('.').Last();
             this.Description = description;
             try
             {
@@ -44,7 +44,7 @@ namespace AvaloniaExamples
         {
             get
             {
-                return this.MainWindowType.Namespace.Split('.').Last() + ".png";
+                return this.Title + ".png";
             }
         }
 

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/AreaDemo/MainWindow.xaml
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/AreaDemo/MainWindow.xaml
@@ -7,7 +7,7 @@
         <oxy:Plot Title="LineSeries and AreaSeries">
             <oxy:Plot.Series>
                 <oxy:AreaSeries Items="{Binding Measurements}" Title="Maximum/Minimum" DataFieldX="Time" DataFieldY="Maximum" DataFieldX2="Time" DataFieldY2="Minimum" Fill="LightBlue" StrokeThickness="0" />
-                <oxy:LineSeries Items="{Binding Measurements}" Title="Average" DataFieldX="Time" DataFieldY="Value" Color="Blue" StrokeThickness="2" Smooth="False"/>
+                <oxy:LineSeries Items="{Binding Measurements}" Title="Average" DataFieldX="Time" DataFieldY="Value" Color="Blue" StrokeThickness="2" />
             </oxy:Plot.Series>
         </oxy:Plot>
     </DockPanel>

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/BindingDemo/MainWindow.xaml
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/BindingDemo/MainWindow.xaml
@@ -1,5 +1,7 @@
 ﻿<Window 
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:oxy="clr-namespace:OxyPlot.Avalonia;assembly=OxyPlot.Avalonia"
+        xmlns="https://github.com/avaloniaui" 
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:oxy="clr-namespace:OxyPlot.Avalonia;assembly=OxyPlot.Avalonia"
         Title="BindingDemo" Width="640"
         Height="480">
   <Grid>

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/ToolTipDemo/MainWindow.xaml
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/ToolTipDemo/MainWindow.xaml
@@ -11,7 +11,7 @@
         <oxy:Plot Title="Hover to see tool tip" Height="200" TitleToolTip="Custom title tool tip via xaml">
             <oxy:Plot.Series>
                 <oxy:AreaSeries Items="{Binding Measurements}" Title="Maximum/Minimum" DataFieldX="Time" DataFieldY="Maximum" DataFieldX2="Time" DataFieldY2="Minimum" Fill="LightBlue" StrokeThickness="0"/>
-                <oxy:LineSeries Items="{Binding Measurements}" Title="Average" DataFieldX="Time" DataFieldY="Value" Color="Blue" StrokeThickness="2" Smooth="False"/>
+                <oxy:LineSeries Items="{Binding Measurements}" Title="Average" DataFieldX="Time" DataFieldY="Value" Color="Blue" StrokeThickness="2" />
             </oxy:Plot.Series>
         </oxy:Plot>
     </StackPanel>

--- a/Source/OxyPlot.Avalonia/Series/TwoColorAreaSeries.cs
+++ b/Source/OxyPlot.Avalonia/Series/TwoColorAreaSeries.cs
@@ -7,6 +7,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Linq;
 using Avalonia;
 
 namespace OxyPlot.Avalonia
@@ -16,8 +17,13 @@ namespace OxyPlot.Avalonia
     /// <summary>
     /// The Avalonia wrapper for OxyPlot.TwoColorAreaSeries.
     /// </summary>
-    public class TwoColorAreaSeries : TwoColorLineSeries
+    public class TwoColorAreaSeries : AreaSeries
     {
+        /// <summary>
+        /// Identifies the <see cref="Dashes2"/> dependency property.
+        /// </summary>
+        public static readonly StyledProperty<double[]> Dashes2Property = AvaloniaProperty.Register<TwoColorAreaSeries, double[]>(nameof(Dashes2));
+        
         /// <summary>
         /// Identifies the <see cref="Fill"/> dependency property.
         /// </summary>
@@ -28,6 +34,16 @@ namespace OxyPlot.Avalonia
         /// </summary>
         public static readonly StyledProperty<Color> Fill2Property = AvaloniaProperty.Register<TwoColorAreaSeries, Color>(nameof(Fill2), MoreColors.Automatic);
 
+        /// <summary>
+        /// Identifies the <see cref="LineStyle2"/> dependency property.
+        /// </summary>
+        public static readonly StyledProperty<LineStyle> LineStyle2Property = AvaloniaProperty.Register<TwoColorAreaSeries, LineStyle>(nameof(LineStyle2));
+
+        /// <summary>
+        /// Identifies the <see cref="Limit"/> dependency property.
+        /// </summary>
+        public static readonly AvaloniaProperty LimitProperty = AvaloniaProperty.Register<TwoColorAreaSeries, double>(nameof(Limit));
+        
         /// <summary>
         /// Identifies the <see cref="MarkerFill2"/> dependency property.
         /// </summary>
@@ -44,6 +60,21 @@ namespace OxyPlot.Avalonia
         public TwoColorAreaSeries()
         {
             InternalSeries = new OxyPlot.Series.TwoColorAreaSeries();
+        }
+
+        /// <summary>
+        /// Gets or sets the dash array for the rendered line that is below the limit (overrides <see cref="LineStyle" />).
+        /// </summary>
+        public double[] Dashes2
+        {
+            get
+            {
+                return GetValue(Dashes2Property);
+            }
+            set
+            {
+                SetValue(Dashes2Property, value);
+            }
         }
 
         /// <summary>
@@ -109,6 +140,38 @@ namespace OxyPlot.Avalonia
                 SetValue(MarkerStroke2Property, value);
             }
         }
+        
+        /// <summary>
+        /// Gets or sets the line style for the part of the line that is below the limit.
+        /// </summary>
+        public LineStyle LineStyle2
+        {
+            get
+            {
+                return (LineStyle)this.GetValue(LineStyle2Property);
+            }
+
+            set
+            {
+                this.SetValue(LineStyle2Property, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a baseline for the series.
+        /// </summary>
+        public double Limit
+        {
+            get
+            {
+                return (double)this.GetValue(LimitProperty);
+            }
+
+            set
+            {
+                this.SetValue(LimitProperty, value);
+            }
+        }
 
         /// <summary>
         /// Synchronizes the properties.
@@ -122,6 +185,9 @@ namespace OxyPlot.Avalonia
             s.Fill2 = Fill2.ToOxyColor();
             s.MarkerFill2 = MarkerFill2.ToOxyColor();
             s.MarkerStroke2 = MarkerStroke2.ToOxyColor();
+            s.Limit = Limit;
+            s.Dashes2 = Dashes2?.ToArray();
+            s.LineStyle2 = LineStyle2;
         }
 
         static TwoColorAreaSeries()
@@ -130,6 +196,9 @@ namespace OxyPlot.Avalonia
             Fill2Property.Changed.AddClassHandler<TwoColorAreaSeries>(AppearanceChanged);
             MarkerFill2Property.Changed.AddClassHandler<TwoColorAreaSeries>(AppearanceChanged);
             MarkerStroke2Property.Changed.AddClassHandler<TwoColorAreaSeries>(AppearanceChanged);
+            LimitProperty.Changed.AddClassHandler<TwoColorAreaSeries>(AppearanceChanged);
+            Dashes2Property.Changed.AddClassHandler<TwoColorAreaSeries>(AppearanceChanged);
+            LineStyle2Property.Changed.AddClassHandler<TwoColorAreaSeries>(AppearanceChanged);
         }
     }
 }

--- a/Source/OxyPlot.Avalonia/Themes/Default.xaml
+++ b/Source/OxyPlot.Avalonia/Themes/Default.xaml
@@ -28,7 +28,7 @@
                   StrokeDashArray="{TemplateBinding LineDashArray}" />
                         <Panel Name="PART_ContentContainer" ClipToBounds="False">
                             <Path Name="PART_Path" Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}"
-                    StrokeThickness="{TemplateBinding BorderThickness, Converter={Static converters:ThicknessConverter.Instance}}" />
+                    StrokeThickness="{TemplateBinding BorderThickness, Converter={x:Static converters:ThicknessConverter.Instance}}" />
                             <ContentPresenter Name="PART_Content" Content="{TemplateBinding Content}" HorizontalAlignment="Center" />
                         </Panel>
                     </Panel>

--- a/Source/OxyPlot.Avalonia/Themes/Default.xaml
+++ b/Source/OxyPlot.Avalonia/Themes/Default.xaml
@@ -76,7 +76,7 @@
                 <ControlTemplate>
                     <local:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
                         <local:TrackerControl.Content>
-                            <TextBlock Text="{Binding Text}" />
+                            <TextBlock Text="{Binding Text}" Margin="7" />
                         </local:TrackerControl.Content>
                     </local:TrackerControl>
                 </ControlTemplate>

--- a/Source/OxyPlot.Avalonia/Utilities/ConverterExtensions.cs
+++ b/Source/OxyPlot.Avalonia/Utilities/ConverterExtensions.cs
@@ -410,7 +410,7 @@ namespace OxyPlot.Avalonia
             {
                 Position = e.GetPosition(relativeTo).ToScreenPoint(),
                 ModifierKeys = Keyboard.Instance.GetModifierKeys(),
-                Delta = (int)e.Delta.Length
+                Delta = (int)(e.Delta.Y + e.Delta.X) * 120
             };
         }
 


### PR DESCRIPTION
This small fixes for:
- loading BindingDemo, TwoColorAreaDemo, AreaDemo and ToolTipDemo (earlier it crashed demo)
- run examples in debug mode in Rider
- reaction of TrackerControl after left mouse button on chart (earlier it crashed demo)
- showing titles and previews in list of demos (earlier was no previews and names of demos with namespaces)
- zooming (earlier zoom was very slow and always scale up chart without depending on direction of wheel rotating)