### PR TITLE
Fix CanvasRenderContext to set Stroke if greater than zero

### DIFF
--- a/Source/OxyPlot.Avalonia/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Avalonia/CanvasRenderContext.cs
@@ -828,9 +828,8 @@ namespace OxyPlot.Avalonia
                     // The default StrokeLineJoin is Miter
                 }
 
-                if (Math.Abs(thickness - 1) > double.Epsilon)
+                if (thickness > 0)
                 {
-                    // only set if different from the default value (1)
                     shape.StrokeThickness = thickness;
                 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes bug behavior where axes and grid lines wouldn't draw



**What is the current behavior?**
Non-drawing lines with default weight. Code assumed default was 1 but it was 0



**What is the new behavior?**
Accepts all positive weights and sets it each time whether it is the default, 0, or not.


